### PR TITLE
Implemented storage of recent routes

### DIFF
--- a/app/src/main/java/edu/wit/mobileapp/monumap/Home.java
+++ b/app/src/main/java/edu/wit/mobileapp/monumap/Home.java
@@ -16,6 +16,8 @@ import android.view.View;
 import android.widget.Button;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 import edu.wit.mobileapp.monumap.Dialogs.Settings;
 import edu.wit.mobileapp.monumap.Entities.Direction;
@@ -55,7 +57,7 @@ public class Home extends AppCompatActivity implements NavigationView.OnNavigati
             @Override
             public void onClick(View view) {
                 // get start location data --> save to route
-                Location start = new Location("Wentworth", 2, 205);
+                Location start = new Location("Wentworth", 2, 208);
 
                 // get end location data --> save to route
                 Location destination = new Location("Wentworth", 1, 107);
@@ -95,11 +97,7 @@ public class Home extends AppCompatActivity implements NavigationView.OnNavigati
                 drawerLayout.closeDrawer(GravityCompat.START);
                 break;
             case R.id.nav_recent_routes:
-                ArrayList<Route> recentRoutesList = createTestRoutes();
                 Intent i = new Intent(Home.this, RecentRoutes.class);
-                Bundle bundle = new Bundle();
-                bundle.putSerializable("recentRoutesList", recentRoutesList);
-                i.putExtras(bundle);
                 startActivity(i);
                 break;
             default:
@@ -121,21 +119,5 @@ public class Home extends AppCompatActivity implements NavigationView.OnNavigati
 
     private void initializeStorage() {
         sharedPreferences = getSharedPreferences(getString(R.string.preferences), Context.MODE_PRIVATE);
-    }
-
-    private ArrayList<Route> createTestRoutes() {
-        ArrayList<Route> res = new ArrayList<>();
-        for(int i = 0; i < 14; i++) {
-            Location start = new Location("Wentworth", 1, i);
-            Location destination = new Location("Wentworth", 1, 107);
-            ArrayList<Instruction> instructions = new ArrayList<>();
-            instructions.add(new Instruction("Take a right", Direction.RIGHT, 1, 1));
-            instructions.add(new Instruction("Go down the stairs", Direction.STAIRS, 1, 1));
-            int duration = 3;
-            int distance = 3;
-            res.add(new Route(instructions, start, destination, duration, distance, 0));
-        }
-
-        return res;
     }
 }

--- a/app/src/main/java/edu/wit/mobileapp/monumap/Instructions.java
+++ b/app/src/main/java/edu/wit/mobileapp/monumap/Instructions.java
@@ -1,5 +1,6 @@
 package edu.wit.mobileapp.monumap;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.design.widget.BottomNavigationView;
 import android.support.v7.app.AppCompatActivity;
@@ -57,6 +58,9 @@ public class Instructions extends AppCompatActivity {
         currentRoute = (Route) getIntent().getSerializableExtra("currentRoute");
         instructions = (ArrayList<Instruction>) currentRoute.getInstructions().clone();     // clone to not overwrite base instructions for route
         previousInstructions = new Stack<>();
+
+        // store new route in recent routes
+        RecentRoutes.updateRecentRoutes(getSharedPreferences(getString(R.string.preferences), MODE_PRIVATE), currentRoute);
 
         // create nav menu
         mBottomNavigationView = findViewById(R.id.nav_view);

--- a/app/src/main/java/edu/wit/mobileapp/monumap/RecentRoutes.java
+++ b/app/src/main/java/edu/wit/mobileapp/monumap/RecentRoutes.java
@@ -10,6 +10,10 @@ import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.ListView;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 
 import edu.wit.mobileapp.monumap.Adapters.RecentRoutesListAdapter;
@@ -23,12 +27,14 @@ public class RecentRoutes extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_recent_routes);
 
-        // take in list and initialize
-        ArrayList<Route> tmpRecentRoutesList = (ArrayList<Route>) getIntent().getSerializableExtra("recentRoutesList");
-        ArrayList<Route> recentRoutesList = new ArrayList<>();
-
         // created shared preferences
         SharedPreferences sharedPreferences = getSharedPreferences(getString(R.string.preferences), Context.MODE_PRIVATE);
+
+        // take in list and initialize
+        ArrayList<Route> tmpRecentRoutesList = getRecentRoutes(sharedPreferences);
+        ArrayList<Route> recentRoutesList = new ArrayList<>();
+
+        // modify list based on specified number from settings
         int numRoutes = sharedPreferences.getInt(getString(R.string.sp_recentRoutesNumber), 1);
         if(numRoutes > tmpRecentRoutesList.size()) {
             numRoutes = tmpRecentRoutesList.size();
@@ -52,8 +58,6 @@ public class RecentRoutes extends AppCompatActivity {
         calculateButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                // add route to top of recent routes
-
                 Intent i = new Intent(RecentRoutes.this, Instructions.class);
                 Bundle bundle = new Bundle();
                 bundle.putSerializable("currentRoute", selectedRoute);
@@ -73,5 +77,39 @@ public class RecentRoutes extends AppCompatActivity {
                 calculateButton.setVisibility(View.VISIBLE);
             }
         });
+    }
+
+    public static void updateRecentRoutes(SharedPreferences sharedPreferences, Route recentRoute) {
+        // get recent routes list
+        ArrayList<Route> recentRoutesList = getRecentRoutes(sharedPreferences);
+
+        // update list with new Route
+        recentRoutesList.add(0, recentRoute);
+        if(recentRoutesList.size() > 20) {
+            int count = recentRoutesList.size();
+            while(count > 20) {
+                recentRoutesList.remove(count);
+                count--;
+            }
+        }
+
+        // put list using Gson
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        Gson gson = new Gson();
+        String json = gson.toJson(recentRoutesList);
+        editor.putString("recentRoutesList", json);
+        editor.apply();
+    }
+
+    private static ArrayList<Route> getRecentRoutes(SharedPreferences sharedPreferences) {
+        Gson gson = new Gson();
+        String json = sharedPreferences.getString("recentRoutesList", null);
+        Type type = new TypeToken<ArrayList<Route>>() {}.getType();
+        ArrayList<Route> recentRoutesList = gson.fromJson(json, type);
+
+        if(recentRoutesList == null) {
+            recentRoutesList = new ArrayList<>();
+        }
+        return recentRoutesList;
     }
 }


### PR DESCRIPTION
Managed to put list of recent routes in shared preferences.

Fully implemented recent routes, allowing to calculate a route directly from the recent routes page when a route is selected. Routes are stored when transitioning to instructions page to ensure only successfully generated routes are stored.